### PR TITLE
Live manager

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -270,7 +270,7 @@ Every program has its own latest log event at `/programs/<SHORTNAME>/latest`. In
 
 ```
 {
-	"type": "episode-start",
+	"event": "episode-start",
 	"episode" : {...},
 	"program" : {...}
 }
@@ -280,7 +280,7 @@ Episode start and end events contain the same information, the epsiode. The end 
 
 ```
 {
-	"type": "episode-end",
+	"event": "episode-end",
 	"episode" : {...},
 	"program" : {...}
 }
@@ -291,7 +291,7 @@ An example of a track log event - note that both track and episode are included.
 
 ```
 {
-	"type": "track-log",
+	"event": "track-log",
 	"program" : {...},
 	"episode" : {...},
 	"track" : {

--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -264,31 +264,23 @@ By default, recording start and recording end is delayed by 12 seconds. You can 
 Independently from the the timestamps or recording of an episode, tracks can be timestamped as well. To log a track, make a GET request to `/episodes/<EPISODEID>/tracks/<TRACKID>/log`. This will place a `log_time` attribute to the track.
 
 
-#### Subscribing to live events
+#### Querying latest log
 
-Whenever a live event (start of an episode, end of an episode or the logging of a track) happens this event is published on one or more [Server Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) channels.
-
-Every program has its own channel at `/programs/<SHORTNAME>/live` that receives these events. In addition all organizations a program belongs to also receive the event at `/organizations/<ORGANIZATIONNAME>/live`:
+Every program has its own latest log event at `/programs/<SHORTNAME>/latest`. In addition, all organizations a program belongs to also gets the latest event at `/organizations/<ORGANIZATIONNAME>/latest`:
 
 ```
-data: {
-	"id": 1,
-	"event": {
-		"type": "episode-start",
-		"episode" : {...}
-	}
+{
+	"type": "episode-start",
+	"episode" : {...}
 }
 
 ```
 Episode start and end events contain the same information, the epsiode. The end episode will also have contain updated tracks, if any exist.
 
 ```
-data: {
-	"id": 1,
-	"event": {
-		"type": "episode-end",
-		"episode" : {...}
-	}
+{
+	"type": "episode-end",
+	"episode" : {...}
 }
 
 ```
@@ -296,25 +288,22 @@ data: {
 An example of a track log event - note that both track and episode are included.
 
 ```
-data: {
-	"id": 1,
-	"event": {
-		"type": "track-log",
-		"episode" : {...},
-		"track" : {
-			"artist": "Beirut",
-			"log_time": "2016-03-15T02:54:02.016+00:00",
-			"mbid": "2984729d-fb43-420b-9d03-d9e34562d843",
-			"title": "Elephant Gun",
-			"id": "56e77948c49c530020f9a2e6"
-		}
+{
+	"type": "track-log",
+	"episode" : {...},
+	"track" : {
+		"artist": "Beirut",
+		"log_time": "2016-03-15T02:54:02.016+00:00",
+		"mbid": "2984729d-fb43-420b-9d03-d9e34562d843",
+		"title": "Elephant Gun",
+		"id": "56e77948c49c530020f9a2e6"
 	}
 }
 
 ```
 
 ##### Handling timestamps manually
-Just like any other field, `start_time`, `end_time` and `log_time` attributes can be set via a JSON HTTP POST request just like when editing the `name` or `description` attributes. However, this method of setting time will not send live events.
+Just like any other field, `start_time`, `end_time` and `log_time` attributes can be set via a JSON HTTP POST request just like when editing the `name` or `description` attributes. However, this method of setting time will not send live events or update the latest logs.
 
 ### XML Feed (for iTunes and other podcasting clients)
 Teal produces an iTunes compliant XML feed for podcasting. This can be found at `/programs/<SHORTNAME>/feed.xml`:

--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -271,7 +271,8 @@ Every program has its own latest log event at `/programs/<SHORTNAME>/latest`. In
 ```
 {
 	"type": "episode-start",
-	"episode" : {...}
+	"episode" : {...},
+	"program" : {...}
 }
 
 ```
@@ -280,7 +281,8 @@ Episode start and end events contain the same information, the epsiode. The end 
 ```
 {
 	"type": "episode-end",
-	"episode" : {...}
+	"episode" : {...},
+	"program" : {...}
 }
 
 ```
@@ -290,6 +292,7 @@ An example of a track log event - note that both track and episode are included.
 ```
 {
 	"type": "track-log",
+	"program" : {...},
 	"episode" : {...},
 	"track" : {
 		"artist": "Beirut",

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,8 +1,5 @@
-FROM z7zmey/nginx-push-stream
-
-COPY ./config/nginx-prod.conf /etc/nginx/nginx.conf
+FROM nginx
+COPY ./config/nginx.conf /etc/nginx/nginx.conf
 COPY ./frontend /frontend
-
-EXPOSE 443
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Teal is a audio and feed host with a program-episode relationship. It automatica
 
 Teal is composed of several Docker containers, managed with Docker Compose:
 
-![Teal Setup](http://i.imgur.com/DHoo1Yk.png)
+![Teal Setup](http://i.imgur.com/PVnNXVZ.png)
 
 ### Simple deployment (using docker-compose)
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -64,7 +64,7 @@ http {
 			if ($request_method != GET) { 
             return 403;
       }
-	  	proxy_pass http://live-manager_upstream  
+	  	proxy_pass http://live-manager_upstream;
 		}
 
     # block where we pass acme challenges to acmetool
@@ -158,12 +158,6 @@ http {
   # server block where nginx will listen to incoming uploads from the encoder
 	server {
 		listen 23021;
-		location ~ /(organizations|programs)/(.*)/live/publish  {
-				allow 172.16.0.0/12; #this should be set to the ip range containers share internally.
-		    deny  all;
-        push_stream_publisher admin;
-        push_stream_channels_path $1-$2;
-    }
 
     location / {
 			proxy_cache_bypass $http_pragma;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -4,12 +4,10 @@ events {
 
 http {
   # set client max body size to allow single request file uploads
-	client_max_body_size 200M;
+	client_max_body_size 500M;
 
   # don't send nginx version with every response
   server_tokens off;
-
-	push_stream_shared_memory_size 64M;
 
   # set api request throttling
 	limit_req_zone $binary_remote_addr zone=api:10m rate=4r/s;
@@ -23,7 +21,11 @@ http {
   upstream acmetool {
     server 127.0.0.1:402;
   }
-  
+ 
+	# set upstream live manager
+	upstream live-manager_upstream {
+		server live-manager:8080;
+	} 
 
   # send the corrent MIME type with static files
   include /etc/nginx/mime.types;
@@ -57,13 +59,13 @@ http {
     access_log off;
 
     # block where nginx manages server sent events
-		location ~ /(organizations|programs)/(.*)/live {
-        push_stream_subscriber eventsource;
-        push_stream_channels_path $1-$2;
-        push_stream_message_template "{\"id\":~id~,\"event\":~text~}";
-        push_stream_ping_message_interval 10s;
-        push_stream_allowed_origins *;
-    }
+		location ~ /(organizations|programs)/(.*)/latest {
+			#refuse if the method is not get
+			if ($request_method != GET) { 
+            return 403;
+      }
+	  	proxy_pass http://live-manager_upstream  
+		}
 
     # block where we pass acme challenges to acmetool
     location /.well-known/acme-challenge/ {

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
   # set client max body size to allow single request file uploads
-	client_max_body_size 500M;
+	client_max_body_size 800M;
 
   # don't send nginx version with every response
   server_tokens off;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -64,6 +64,7 @@ http {
 			if ($request_method != GET) { 
             return 403;
       }
+      add_header 'Access-Control-Allow-Origin' '*';
 	  	proxy_pass http://live-manager_upstream;
 		}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
   container_name: redis
   image: redis
 
+ live_manager: 
+  container_name: live-manager
+  build: ./live-manager
+
  mongo:
   container_name: mongo
   image: mongo
@@ -52,7 +56,6 @@ services:
    context: .
    dockerfile: Dockerfile-nginx
   volumes: 
-   - /frontend:/usr/src/app/frontend:ro
    - /var/lib/acme/:/var/lib/acme/:ro
   ports:
    - "80:80"

--- a/frontend/episode.html
+++ b/frontend/episode.html
@@ -29,7 +29,7 @@
 
                 <div class="btn-group btn-group-justified" role="group" aria-label="...">
                   <div class="btn-group" role="group">
-                    <button class="btn btn-success btn-sm" ng-if="!episode.start_time && !episode.end_time" type="button" ng-click="startEpisode()">Start recording</button>
+                    <button class="btn btn-success btn-sm" ng-if="!episode.start_time && !episode.end_time" type="button" ng-click="startEpisode()">Start episode</button>
                     <button type="button" ng-if="episode.start_time" class="center-block btn btn-default btn-sm" disabled="disabled">Started {{ episode.start_time | date:"h:mma" }}</button>
                   </div>
                   <div class="btn-group" role="group">

--- a/frontend/js/episodeController.js
+++ b/frontend/js/episodeController.js
@@ -10,7 +10,7 @@ yellow.controller('episodeController', function ($interval, $filter, $http, teal
   $scope.episode = Episode.get({id: $route.current.params.id});
   $scope.tracks = Track.query({id: $route.current.params.id});
   $scope.newTrack = new Track();
-  $scope.endRecordingText = 'End recording';
+  $scope.endRecordingText = 'End episode';
 
   // interval to increment the timer
   var timerinterval = $interval( $scope.timer, 1000);

--- a/frontend/js/episodeModalController.js
+++ b/frontend/js/episodeModalController.js
@@ -3,6 +3,7 @@ yellow.controller('episodeModalController', function ($scope, $location, $uibMod
 
   $scope.isFirstOpen = true;
   
+  $scope.episode.name = $filter('date')(new Date(), 'MM-dd-yyyy');
   $scope.save = function () {
     $scope.episode.$save(function () {
       $uibModalInstance.close();

--- a/frontend/js/episodeModalController.js
+++ b/frontend/js/episodeModalController.js
@@ -1,9 +1,9 @@
-yellow.controller('episodeModalController', function ($scope, $location, $uibModalInstance,$log,  episode) {
+yellow.controller('episodeModalController', function ($filter, $scope, $location, $uibModalInstance,$log,  episode) {
   $scope.episode = episode;
 
   $scope.isFirstOpen = true;
   
-  $scope.episode.name = $filter('date')(new Date(), 'MM-dd-yyyy');
+  $scope.episode.name = $filter('date')(new Date(), 'MMMM dd, yyyy');
   $scope.save = function () {
     $scope.episode.$save(function () {
       $uibModalInstance.close();

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -41,7 +41,7 @@
     <h4>Show notes with Markdown</h4>
     <p>Teal shows your show notes correctly on iTunes streams with markdown support. Links on iTunes and other providers become clickable.</p>
 
-    <h4>Log songs and subscribe to feeds</h4>
-    <p>Teal allows you to keep track of the songs on your episode. You can also subscribe to the logs live using <a href="https://en.wikipedia.org/wiki/Server-sent_events">SSE</a> if you're recording from a stream and logging at the same time. This is handy if you have a broadcast stream and want to associate tracks with the time it played on the stream.</p>
+    <!-- <h4>Log songs and subscribe to feeds</h4>
+    <p>Teal allows you to keep track of the songs on your episode. You can also subscribe to the logs live using <a href="https://en.wikipedia.org/wiki/Server-sent_events">SSE</a> if you're recording from a stream and logging at the same time. This is handy if you have a broadcast stream and want to associate tracks with the time it played on the stream.</p> -->
   </div>
 </div>

--- a/live-manager/Dockerfile
+++ b/live-manager/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:onbuild
+EXPOSE 8080

--- a/live-manager/live-manager.go
+++ b/live-manager/live-manager.go
@@ -1,0 +1,59 @@
+//This program handles the "what is playing right now" requests by returning the last played tracks for every program and organization.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// map of strings for organizations
+var organizations = make(map[string]string)
+
+// map of strings for programs
+var programs = make(map[string]string)
+
+// all requests are handled by one function for now
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	//strip the first forward slash and strip url into components
+	urlPath := strings.Split(r.URL.Path[1:], "/")
+
+	//return error if the url is not complete
+	if len(urlPath) < 2 {
+		fmt.Fprintf(w, "{'error':'url not properly formatted'}")
+		return
+	}
+
+	entityName := urlPath[1]
+
+	// post a new log - this method should be closed to outside users
+	if r.Method == "POST" {
+		// read from the reader to the buffer
+		buffer := new(bytes.Buffer)
+		buffer.ReadFrom(r.Body)
+		body := buffer.String()
+		if urlPath[0] == "organizations" {
+			organizations[entityName] = body
+		} else if urlPath[0] == "programs" {
+			programs[entityName] = body
+		} else {
+			fmt.Fprintf(w, "{'error':'posting a new log, url not properly formatted'}")
+		}
+	} else {
+		//determine if the first part of the url is orgs or progs
+		if urlPath[0] == "organizations" {
+			fmt.Fprintf(w, organizations[entityName])
+		} else if urlPath[0] == "programs" {
+			fmt.Fprintf(w, programs[entityName])
+		} else {
+			fmt.Fprintf(w, "{'error':'url not properly formatted'}")
+		}
+	}
+}

--- a/recorder/recorder.rb
+++ b/recorder/recorder.rb
@@ -12,7 +12,7 @@ module Recorder
   #   At the end of the recording, recorder uploads the file back to the server.
   class Recorder < Sinatra::Base
     API_URI = 'nginx:23021'.freeze
-    LIMIT = 2
+    LIMIT = 3
 
     configure do
       set :port, 80
@@ -32,7 +32,7 @@ module Recorder
 
       halt 400 if @@recording.length == LIMIT # limit reached
 
-      stream.thread = Thread.new { timeout(10_800) { record(stream) } }
+      stream.thread = Thread.new { timeout(25_200) { record(stream) } }
       @@recording.push(stream)
       @@recording.each do |s|
         p "Stream ep id is: #{s.episode_id}"

--- a/teal/api_episode.rb
+++ b/teal/api_episode.rb
@@ -97,7 +97,7 @@ module Teal
 			episode.start_time = Time.now + episode.delay
 			episode.save
 
-      Live.publish( {:type => "episode-start", :episode => episode, :program => episode.program }, episode.program, episode.delay)
+      Live.publish( {:event => "episode-start", :episode => episode, :program => episode.program }, episode.program, episode.delay)
 
 			200
 		end
@@ -115,7 +115,7 @@ module Teal
 			episode.end_time = Time.now #delay is already added at the recorder
 			episode.save
 
-      Live.publish( {:type => "episode-end", :episode => episode, :program => episode.program }, episode.program, 0)
+      Live.publish( {:event => "episode-end", :episode => episode, :program => episode.program }, episode.program, 0)
 
 			200
 		end

--- a/teal/api_episode.rb
+++ b/teal/api_episode.rb
@@ -97,7 +97,7 @@ module Teal
 			episode.start_time = Time.now + episode.delay
 			episode.save
 
-      Live.publish( {:type => "episode-start", :episode => episode }, episode.program, episode.delay)
+      Live.publish( {:type => "episode-start", :episode => episode, :program => episode.program }, episode.program, episode.delay)
 
 			200
 		end
@@ -115,7 +115,7 @@ module Teal
 			episode.end_time = Time.now #delay is already added at the recorder
 			episode.save
 
-      Live.publish( {:type => "episode-end", :episode => episode }, episode.program, 0)
+      Live.publish( {:type => "episode-end", :episode => episode, :program => episode.program }, episode.program, 0)
 
 			200
 		end

--- a/teal/api_track.rb
+++ b/teal/api_track.rb
@@ -67,7 +67,7 @@ module Teal
 				track.log_time = Time.now + episode.delay
 				episode.save
 
-	      Live.publish( {:type => "track-log", :track => track, :epsiode => episode}, episode.program, episode.delay)
+	      Live.publish( {:type => "track-log", :track => track, :epsiode => episode, :program => episode.program}, episode.program, episode.delay)
 
 				return track.to_json
 			else

--- a/teal/api_track.rb
+++ b/teal/api_track.rb
@@ -67,7 +67,7 @@ module Teal
 				track.log_time = Time.now + episode.delay
 				episode.save
 
-	      Live.publish( {:type => "track-log", :track => track, :epsiode => episode, :program => episode.program}, episode.program, episode.delay)
+	      Live.publish( {:event => "track-log", :track => track, :epsiode => episode, :program => episode.program}, episode.program, episode.delay)
 
 				return track.to_json
 			else

--- a/teal/live.rb
+++ b/teal/live.rb
@@ -11,21 +11,7 @@ module Teal
     def self.publishAsync(event, program, delay)
 
   		sleep(delay.to_i)
-
-			uri = URI("http://nginx:23021/programs/#{program.shortname}/live/publish")
-      http = Net::HTTP.new(uri.host, uri.port)
-      request = Net::HTTP::Post.new(uri.request_uri)
-      request.body = event.to_json
-      response = http.request(request)
-
-      program.organizations.each do |org|
-      	uri = URI("http://nginx:23021/organizations/#{org}/live/publish")
-	      http = Net::HTTP.new(uri.host, uri.port)
-	      request = Net::HTTP::Post.new(uri.request_uri)
-	      request.body = event.to_json
-	      response = http.request(request)
-      end
-
+      
 			uri = URI("http://live-manager:8080/programs/#{program.shortname}")
       http = Net::HTTP.new(uri.host, uri.port)
       request = Net::HTTP::Post.new(uri.request_uri)

--- a/teal/live.rb
+++ b/teal/live.rb
@@ -25,6 +25,20 @@ module Teal
 	      request.body = event.to_json
 	      response = http.request(request)
       end
+
+			uri = URI("http://live-manager:8080/programs/#{program.shortname}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request.body = event.to_json
+      response = http.request(request)
+
+      program.organizations.each do |org|
+      	uri = URI("http://live-manager:8080/organizations/#{org}")
+	      http = Net::HTTP.new(uri.host, uri.port)
+	      request = Net::HTTP::Post.new(uri.request_uri)
+	      request.body = event.to_json
+	      response = http.request(request)
+      end
     end
 	end
 end


### PR DESCRIPTION
built a new live-manager program to respond to requests like: `/organizations/wjrh/latest` that returns the latest event in that organization when queried. this will replace the server sent events feature until we build a better SSE/WS interface.

the wjrh robodj/liquidsoap integration is still not clean and that's kinda bugging me.
also we will need to somehow inform all djs (aka bill charles) of teal @rcieoktgieke 
